### PR TITLE
프로필 설정에서 닉네임 중복검사 post 요청시 debounce 설정하기 

### DIFF
--- a/src/components/common/Input/ProfileInput.jsx
+++ b/src/components/common/Input/ProfileInput.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
+import { debounce } from 'lodash';
 import { Button, ChipButton } from '../Button/Button';
 import { useForm } from 'react-hook-form';
 import { DevTool } from '@hookform/devtools';
@@ -35,6 +36,7 @@ export default function ProfileInput(props) {
           };
         } else {
           //닉네임 중복검사 post 요청
+
           const response = await axios.post(
             'https://api.mudig.co.kr/user/checkname/',
             { name: data.nickName },
@@ -63,8 +65,6 @@ export default function ProfileInput(props) {
     }
   };
 
-  // const selectedChipsString = selectedChips.join(', ');
-
   const handleNickNameLengthChange = async (event) => {
     let value = event.target.value;
     value = value.slice(0, 8);
@@ -72,6 +72,8 @@ export default function ProfileInput(props) {
 
     setValue('nickName', value, { shouldValidate: true });
   };
+  //loadsh 사용하여 닉네임 Onchange debounce 적용
+  const handleNickNameChecked = debounce(handleNickNameLengthChange, 1000);
 
   return (
     <FormWrap onSubmit={handleSubmit(onSubmit)}>
@@ -88,7 +90,7 @@ export default function ProfileInput(props) {
             placeholder='8글자 내로 작성해주세요'
             type='text'
             id='nickName'
-            onChange={handleNickNameLengthChange}
+            onChange={handleNickNameChecked}
           />
           <CharacterCount>{`${nickNameCount}/8`}</CharacterCount>
         </InputBox>


### PR DESCRIPTION
## PR 타입

<!-- 하나 이상 선택, [x]를 입력해 체크박스 채우기 가능 -->

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 변경 브랜치

ex) feature/setProfile -> develop

## 변경 사항
기존 닉네임 중복검사시 값이 변경될때마다 닉네임 중복검사 post 요청을 보내고 있는 방식, 서버 과부하가 올 수도 있기에 입력 후 1초뒤에 중복검사 요청을 보내도록 lodash에서 제공하는 debounce 함수를 사용하여닉네임 input onchange가 변경된 후 1초의 디바운싱을 적용하였습니다.
<!-- 해당 기능 / 변경사항을 작업한 내용을 요약해 작성 -->

- 유저가 입력한 닉네임 중복검사 post 요청시에 디바운싱 1초로 설정하기
- 기능

## PR 체크리스트
 <!-- 마지막으로 PR을 만들기 전 확인할 목록, [x]를 입력해 체크박스 채우기 가능 -->

- [ ] 📜 PR 제목 형식을 잘 작성했나요?
- [ ] 👀 리뷰어를 설정했나요?
- [ ] 📊 프로젝트를 등록했나요?
- [ ] 💭 이슈를 등록했나요?
- [ ] 🏷️ 라벨을 등록했나요?

## 참고자료
[lodash로 간단하게 debounce 사용하기](https://www.mrlatte.net/code/2020/12/15/lodash-debounce)
