### PR TITLE
비밀번호 변경 페이지 기능구현 & 유저 정보 토큰 설정방식 변경

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "recoil-persist": "^5.1.0",
         "styled-components": "^5.3.10",
         "styled-reset": "^4.5.1",
+        "sweetalert2": "^11.10.1",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -16879,6 +16880,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/sweetalert2": {
+      "version": "11.10.1",
+      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-11.10.1.tgz",
+      "integrity": "sha512-qu145oBuFfjYr5yZW9OSdG6YmRxDf8CnkgT/sXMfrXGe+asFy2imC2vlaLQ/L/naZ/JZna1MPAY56G4qYM0VUQ==",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/limonte"
       }
     },
     "node_modules/symbol-tree": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "recoil-persist": "^5.1.0",
     "styled-components": "^5.3.10",
     "styled-reset": "^4.5.1",
+    "sweetalert2": "^11.10.1",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/public/index.html
+++ b/public/index.html
@@ -1,14 +1,16 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ko">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>React App</title>
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/limonte-sweetalert2/7.2.0/sweetalert2.min.css"
+    />
+  </head>
 
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>React App</title>
-</head>
-
-<body>
-  <div id="root"></div>
-</body>
-
+  <body>
+    <div id="root"></div>
+  </body>
 </html>

--- a/src/components/common/Form/AuthForm.jsx
+++ b/src/components/common/Form/AuthForm.jsx
@@ -27,8 +27,10 @@ export const AuthForm = () => {
 
   const { mutate } = useMutation(loginUser, {
     onSuccess: (data) => {
-      const { id, email, name, image, genre, about, rep_playlist } = data.user;
-      const token = data.token;
+      const { user, token } = data;
+      const { id, email, name, image, genre, about, rep_playlist } = user;
+      const { access, refresh } = token;
+
       setUserInfo({
         id,
         email,
@@ -39,6 +41,8 @@ export const AuthForm = () => {
         rep_playlist,
         token,
       });
+      localStorage.setItem('token', access);
+      localStorage.setItem('refreshToken', refresh);
       navigate('/main');
       console.log('로그인 성공', data);
     },
@@ -88,8 +92,8 @@ export const AuthForm = () => {
           placeholder='비밀번호를 입력하세요 '
           type='password'
           name='password'
-          showPassword={showPassword}
-          toggleShowPassword={toggleShowPassword}
+          showPassword={showPassword.password}
+          toggleShowPassword={() => toggleShowPassword('password')}
         />
 
         <Label htmlFor='checkbox' onClick={handleCheckboxChange}>

--- a/src/components/common/Form/AuthForm.jsx
+++ b/src/components/common/Form/AuthForm.jsx
@@ -2,7 +2,7 @@ import { useForm, FormProvider } from 'react-hook-form';
 import styled from 'styled-components';
 import { AuthInput } from '../Input/AuthInput';
 import { Button } from '../Button/Button';
-import { userInfoAtom } from '../../../library/atom';
+import { userInfoAtom, isLoginAtom } from '../../../library/atom';
 import { loginUser } from '../../../library/apis/api';
 import { useMutation } from 'react-query';
 import { useSetRecoilState } from 'recoil';
@@ -24,7 +24,7 @@ export const AuthForm = () => {
   const errorMessage =
     '아이디(로그인 전용 아이디) 또는 비밀번호를 잘못 입력했습니다. 입력하신 내용을 다시 확인해 주세요';
   const setUserInfo = useSetRecoilState(userInfoAtom);
-
+  const setIsLogin = useSetRecoilState(isLoginAtom);
   const { mutate } = useMutation(loginUser, {
     onSuccess: (data) => {
       const { user, token } = data;
@@ -41,6 +41,7 @@ export const AuthForm = () => {
         rep_playlist,
         token,
       });
+      setIsLogin(true);
       localStorage.setItem('token', access);
       localStorage.setItem('refreshToken', refresh);
       navigate('/main');

--- a/src/components/common/Form/SignupForm.jsx
+++ b/src/components/common/Form/SignupForm.jsx
@@ -118,8 +118,8 @@ export const SignupForm = ({ onSubmit }) => {
             placeholder='비밀번호'
             type='password'
             name='password'
-            showPassword={showPassword}
-            toggleShowPassword={toggleShowPassword}
+            showPassword={showPassword.password}
+            toggleShowPassword={() => toggleShowPassword('password')}
           />
         </PasswordContainer>
         <ButtonBox>

--- a/src/components/common/Input/SignupInput.jsx
+++ b/src/components/common/Input/SignupInput.jsx
@@ -71,7 +71,7 @@ const InputStyle = styled.input`
 `;
 
 const TimeText = styled.span`
-  color: red;
+  color: var(--error-color);
   position: absolute;
   top: 50%;
   right: 10px;
@@ -87,7 +87,7 @@ const EyeIcon = styled.span`
 `;
 
 const ErrorMsg = styled.span`
-  color: red;
+  color: var(--error-color);
   font-size: 12px;
   text-align: left;
   display: block;

--- a/src/components/common/Input/SignupInput.jsx
+++ b/src/components/common/Input/SignupInput.jsx
@@ -40,7 +40,7 @@ export const SignupInput = (props) => {
         {showTimeText && <TimeText>05:00</TimeText>}
 
         <EyeIcon onClick={toggleShowPassword}>
-          {type === 'password' && (
+          {type === 'password' && name !== 'confirmPassword' && (
             <img
               src={showPassword ? showEye : hideEye}
               alt={showPassword ? '비밀번호 표시' : '비밀번호 숨기기'}

--- a/src/hooks/queries/useUserInfo.jsx
+++ b/src/hooks/queries/useUserInfo.jsx
@@ -1,0 +1,15 @@
+import { useMutation } from 'react-query';
+import { privateInstance } from '../../library/apis/axiosInstance';
+
+export const useChangePassword = () => {
+  const changePassword = async (data) => {
+    const response = await privateInstance.put('/user/changepassword/', {
+      old_password: data.password,
+      new_password: data.newPassword,
+    });
+
+    return response.data;
+  };
+  const mutation = useMutation(changePassword);
+  return mutation;
+};

--- a/src/hooks/ussPasswordToggle.jsx
+++ b/src/hooks/ussPasswordToggle.jsx
@@ -1,13 +1,15 @@
 import { useState } from 'react';
 
 const usePasswordToggle = () => {
-  const [showPassword, setShowPassword] = useState(false);
+  const [showPassword, setShowPassword] = useState({}); // 객체로 변경
 
-  const toggleShowPassword = () => {
-    setShowPassword((prevValue) => !prevValue);
+  const toggleShowPassword = (name) => {
+    setShowPassword((prev) => ({
+      ...prev,
+      [name]: !prev[name], //해당 key값의 true/false만 변경
+    }));
   };
 
   return { toggleShowPassword, showPassword };
 };
-
 export default usePasswordToggle;

--- a/src/library/atom.js
+++ b/src/library/atom.js
@@ -14,8 +14,11 @@ export const SignUpAtom = atom({
 
 export const userInfoAtom = atom({
   key: 'userInfoAtom',
-  default: {
-    isLogin: false,
-  },
+  default: {},
   effects_UNSTABLE: [persistAtom],
+});
+
+export const isLoginAtom = atom({
+  key: 'isLoginAtom',
+  default: localStorage.getItem('token') ? true : false,
 });

--- a/src/pages/EventPage/EventPageStyle.jsx
+++ b/src/pages/EventPage/EventPageStyle.jsx
@@ -25,7 +25,7 @@ export const QuestionBox = styled.div`
   p {
     margin-left: 16px;
     font-size: 22px;
-    font-weight:var(--font-semi-bold)
+    font-weight: var(--font-semi-bold);
   }
   div {
     position: absolute;

--- a/src/pages/Login/Login.jsx
+++ b/src/pages/Login/Login.jsx
@@ -5,7 +5,7 @@ import { AuthForm } from '../../components/common/Form/AuthForm';
 import KakaoIcon from '../../img/kakao-icon.svg';
 import GoogleIcon from '../../img/google-icon.svg';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { userInfoAtom } from '../../library/atom';
+import { isLoginAtom, userInfoAtom } from '../../library/atom';
 import {
   getKakaoInfo,
   getGoogleInfo,
@@ -18,6 +18,7 @@ export default function Login() {
   const setUserInfo = useSetRecoilState(userInfoAtom);
   const navigate = useNavigate();
   const location = useLocation();
+  const setIsLogin = useSetRecoilState(isLoginAtom);
   //카카오, 구글 로그인 링크 get 요청
   const { data: kakaoData } = useQuery('kakao', getKakaoInfo);
   const { data: googleData } = useQuery('google', getGoogleInfo);
@@ -28,6 +29,7 @@ export default function Login() {
   useEffect(() => {
     // 쿼리 파라미터 값 가져오기
     const result = query.get('code') || false;
+
     const hasScope = socialQuery.get('scope');
     //url에서 scope값을 가지고 있다면 send code post 요청시 social = 'google'로 설정
     if ((result, hasScope)) {
@@ -48,9 +50,12 @@ export default function Login() {
       }
       //가입 이력이 있을 경우
       if (response.message === '로그인 성공') {
-        const { id, email, name, image, genre, about, rep_playlist } =
-          response.user;
-        const token = response.token;
+        const { user, token } = response;
+        const { id, email, name, image, genre, about, rep_playlist } = user;
+        const { access, refresh } = token;
+        localStorage.setItem('token', access);
+        localStorage.setItem('refreshToken', refresh);
+        setIsLogin(true);
         setUserInfo({
           id,
           email,
@@ -61,6 +66,7 @@ export default function Login() {
           rep_playlist,
           token,
         });
+
         navigate('/main');
         //가입 이력이 없고 뮤딕 프로필 설정이 필요한 경우
       } else {

--- a/src/pages/SetProfile/SetProfile.jsx
+++ b/src/pages/SetProfile/SetProfile.jsx
@@ -3,8 +3,8 @@ import styled from 'styled-components';
 import ProfileImage from '../../components/common/Image/ProfileImage';
 import UploadImgBtn from '../../img/selectImg.svg';
 import ProfileInput from '../../components/common/Input/ProfileInput';
-import { userInfoAtom } from '../../library/atom';
-import { useRecoilState } from 'recoil';
+import { userInfoAtom, isLoginAtom } from '../../library/atom';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 import { ImgCompression } from '../../library/ImgCompression';
 import { useNavigate } from 'react-router-dom';
 import { postUserProfile } from '../../library/apis/api';
@@ -13,7 +13,7 @@ export default function SetProfile() {
   const navigate = useNavigate();
 
   const [userInfo, setUserInfo] = useRecoilState(userInfoAtom);
-
+  const setIsLogin = useSetRecoilState(isLoginAtom);
   const [genre, setGenre] = useState([]);
   const [previewImg, setPreviewImg] = useState(
     'https://upload.wikimedia.org/wikipedia/commons/2/2c/Default_pfp.svg',
@@ -90,9 +90,12 @@ export default function SetProfile() {
       const response = await postUserProfile(formData, userInfo.type);
 
       if (response.message === '회원가입 성공') {
-        const { id, email, name, image, genre, about, rep_playlist } =
-          response.user;
-        const token = response.token;
+        const { user, token } = response;
+        const { id, email, name, image, genre, about, rep_playlist } = user;
+        const { access, refresh } = token;
+        localStorage.setItem('token', access);
+        localStorage.setItem('refreshToken', refresh);
+        setIsLogin(true);
         setUserInfo({
           id,
           email,

--- a/src/pages/UserInfo/ChangePwForm.jsx
+++ b/src/pages/UserInfo/ChangePwForm.jsx
@@ -4,32 +4,74 @@ import { useForm, FormProvider } from 'react-hook-form';
 import { Button } from '../../components/common/Button/Button';
 import { SignupInput } from '../../components/common/Input/SignupInput';
 import usePasswordToggle from '../../hooks/ussPasswordToggle';
+import { userInfoAtom } from '../../library/atom';
+import { useRecoilValue } from 'recoil';
+import { useMutation } from 'react-query';
+import Swal from 'sweetalert2';
+
+import axios from 'axios';
 export default function ChangePwForm() {
+  const userEmail = useRecoilValue(userInfoAtom).email;
+  const token = useRecoilValue(userInfoAtom).token.access;
   const pawwrodRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).{8,16}$/;
   const methods = useForm({
     defaultValues: {
-      email: 'mudic@naver.com',
+      email: userEmail,
     },
 
     mode: 'onBlur',
   });
-  const { formState } = methods;
+
+  const { formState, setError, watch } = methods;
   const { isValid } = formState;
-  const onSubmit = (data) => console.log(data);
+
+  const { mutate } = useMutation(async (data) => {
+    const { password, newPassword } = data;
+    try {
+      const response = await axios.put(
+        'https://api.mudig.co.kr/user/changepassword/',
+        {
+          old_password: password,
+          new_password: newPassword,
+        },
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        },
+      );
+      Swal.fire({
+        icon: 'success',
+        title: '비밀번호 변경 완료',
+        text: '비밀번호가 성공적으로로 변경되었습니다!',
+      });
+      console.log(response.data);
+    } catch (error) {
+      setError('password', { message: '현재 비밀번호가 일치하지 않습니다.' });
+      console.error('비밀번호 변경 실패', error);
+    }
+  });
+
+  const onSubmit = (data) => {
+    mutate(data);
+  };
   const { toggleShowPassword, showPassword } = usePasswordToggle();
   return (
     <FormProvider {...methods}>
       <FormWrap onSubmit={methods.handleSubmit(onSubmit)}>
         <InputBox>
-          <SignupInput placeholder='아이디' type='text' name='email' />
+          <Label>이메일 </Label>
+          <SignupInput placeholder='이메일' type='text' name='email' />
 
+          <Label>현재 비밀번호</Label>
           <SignupInput
             validation={{
               pattern: {
                 value: pawwrodRegex, //기능개발할땐 기존 유저 비밀번호를 검사해야 됨
                 message: 'X 8~16자 영문 대 소문자, 숫자를 사용하세요.',
               },
-              required: '현재 비밀번호가 기억나지 않으세요?',
+
+              required: '현재 사용중인 비밀번호를 입력하세요.',
             }}
             placeholder='현재 비밀번호'
             type='password'
@@ -37,13 +79,14 @@ export default function ChangePwForm() {
             showPassword={showPassword.password}
             toggleShowPassword={() => toggleShowPassword('password')}
           />
-
+          <Label>새 비밀번호</Label>
           <SignupInput
             validation={{
               pattern: {
                 value: pawwrodRegex,
                 message: 'X 8~16자 영문 대 소문자, 숫자를 사용하세요.',
               },
+
               required: 'X 8~16자 영문 대 소문자, 숫자를 사용하세요.',
             }}
             placeholder='새 비밀번호'
@@ -52,11 +95,20 @@ export default function ChangePwForm() {
             showPassword={showPassword.newPassword}
             toggleShowPassword={() => toggleShowPassword('newPassword')}
           />
+          <Label>새 비밀번호 확인</Label>
           <SignupInput
             validation={{
               pattern: {
                 value: pawwrodRegex,
                 message: 'X 8~16자 영문 대 소문자, 숫자를 사용하세요.',
+              },
+              validate: {
+                comfirmPw: (fieldValue) => {
+                  return (
+                    fieldValue == watch('newPassword') ||
+                    '비밀번호 확인이 일치하지 않습니다.'
+                  );
+                },
               },
               required: 'X 8~16자 영문 대 소문자, 숫자를 사용하세요.',
             }}
@@ -80,7 +132,9 @@ export default function ChangePwForm() {
   );
 }
 
-const FormWrap = styled.form``;
+const FormWrap = styled.form`
+  height: 100%;
+`;
 
 const InputBox = styled.div`
   display: flex;
@@ -92,6 +146,11 @@ const InputBox = styled.div`
 
 const ButtonBox = styled.div`
   position: absolute;
-  top: 680px;
+  top: 755px;
   padding: 0 16px;
+`;
+
+const Label = styled.label`
+  padding-bottom: 8px;
+  font-size: var(--font-md);
 `;

--- a/src/pages/UserInfo/ChangePwForm.jsx
+++ b/src/pages/UserInfo/ChangePwForm.jsx
@@ -8,7 +8,7 @@ import { userInfoAtom } from '../../library/atom';
 import { useRecoilValue } from 'recoil';
 import { useChangePassword } from '../../hooks/queries/useUserInfo';
 import Swal from 'sweetalert2';
-import { Navigate, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 export default function ChangePwForm() {
   const navigate = useNavigate();
@@ -23,9 +23,10 @@ export default function ChangePwForm() {
     mode: 'onBlur',
   });
 
-  const { formState, setError, watch } = methods;
+  const { formState, setError, watch, getValues } = methods;
   const { isValid } = formState;
-
+  const confirmPassword = getValues('confirmPassword');
+  const newPassword = getValues('newPassword');
   const handlePasswordSubmit = (data) => {
     changePassword(data, {
       onSuccess: (data) => {
@@ -55,7 +56,7 @@ export default function ChangePwForm() {
           <SignupInput
             validation={{
               pattern: {
-                value: pawwrodRegex, //기능개발할땐 기존 유저 비밀번호를 검사해야 됨
+                value: pawwrodRegex,
                 message: 'X 8~16자 영문 대 소문자, 숫자를 사용하세요.',
               },
 
@@ -77,9 +78,14 @@ export default function ChangePwForm() {
               },
               validate: {
                 comfirmPw: (fieldValue) => {
-                  return fieldValue === watch('password')
-                    ? '현재 비밀번호와 새 비밀번호는 동일할 수 없습니다.'
-                    : null;
+                  const oldPassword = watch('password');
+                  // const confirmPassword = getValues('confirmPassword');
+                  if (fieldValue === oldPassword) {
+                    return '현재 비밀번호와 새 비밀번호는 동일할 수 없습니다.';
+                  } else if (newPassword !== confirmPassword) {
+                    return '비밀번호 확인이 일치하지 않습니다.';
+                  }
+                  return null;
                 },
               },
               required: 'X 8~16자 영문 대 소문자, 숫자를 사용하세요.',
@@ -147,5 +153,5 @@ const InputBox = styled.div`
 
 const ButtonBox = styled.div`
   position: absolute;
-  top: 755px;
+  bottom: 24px;
 `;

--- a/src/pages/UserInfo/ChangePwForm.jsx
+++ b/src/pages/UserInfo/ChangePwForm.jsx
@@ -8,8 +8,10 @@ import { userInfoAtom } from '../../library/atom';
 import { useRecoilValue } from 'recoil';
 import { useChangePassword } from '../../hooks/queries/useUserInfo';
 import Swal from 'sweetalert2';
+import { Navigate, useNavigate } from 'react-router-dom';
 
 export default function ChangePwForm() {
+  const navigate = useNavigate();
   const userEmail = useRecoilValue(userInfoAtom).email;
   const { mutate: changePassword } = useChangePassword();
   const pawwrodRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).{8,16}$/;
@@ -32,6 +34,7 @@ export default function ChangePwForm() {
           text: '비밀번호가 성공적으로 변경되었습니다!',
           icon: 'success',
         });
+        navigate('/user/profile/my');
         console.log(data);
       },
       onError: (error) => {

--- a/src/pages/UserInfo/UserLeaveForm.jsx
+++ b/src/pages/UserInfo/UserLeaveForm.jsx
@@ -58,6 +58,6 @@ const InputBox = styled.div`
 
 const ButtonBox = styled.div`
   position: absolute;
-  top: 680px;
+  top: 755px;
   padding: 0 16px;
 `;

--- a/src/routes/PrivateRoutes.js
+++ b/src/routes/PrivateRoutes.js
@@ -2,13 +2,10 @@ import React from 'react';
 import { useRecoilValue } from 'recoil';
 
 import { Outlet, Navigate } from 'react-router-dom';
-
+import { isLoginAtom } from '../library/atom';
 export default function PrivateRoute() {
   // 로그인 여부 확인
-
-  // const isLogin = useRecoilValue(false); // Recoil로 관리 중인 로그인 상태값으로 교체
-
-  const isLogin = true;
+  const isLogin = useRecoilValue(isLoginAtom);
 
   return isLogin ? <Outlet /> : <Navigate to='/login' />;
 }


### PR DESCRIPTION
## PR 타입

<!-- 하나 이상 선택, [x]를 입력해 체크박스 채우기 가능 -->

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 변경 브랜치

ex) feature/userInfo -> develop

## 변경 사항
1.유저정보 토큰 localStorage로 관리 #82 
- 로그인, 회원가입 시 토큰 로컬스토리지에 저장
- 로컬스토리지 토큰값 존재 여부에 따라 isLogin 상태 설정
- privateRouter에서 isLogin이 false면 유저정보가 필요한 페이지 접근 불가 설정

<!-- 해당 기능 / 변경사항을 작업한 내용을 요약해 작성 -->
2.현재 비밀번호와 새 비밀번호를 설정하여 비밀번호 변경 유효성 검사 진행 #80 
 - 새 비밀번호와 새 비밀번호 확인이 일치하는지 유효성 검사 진행 및 비밀번호 변경 put 요청
 - form 제출시 현재 비밀번호와 새 비밀번호 put 요청 보내기
 - put 요청 후 현재 비밀번호가 일치하지 않을시 비밀번호 input filed에 '현재 비밀번호가 일치하지 않습니다.' 에러 메시지 출력
 - 정상적으로 비밀번호 변경 시 '비밀번호가 정상적으로 변경되었습니다' 모달 띄우고 마이 프로필로 이동
 

3. 비밀번호 보기/ 숨기기 기능 버그 해결 재설정 #28 
- 기존에 수정해 두었던 비밀번호 보기 버그 수정 코드가 develop에서 사라져서 해결코드 다시 재설정하였습니다. 
## PR 체크리스트



 <!-- 마지막으로 PR을 만들기 전 확인할 목록, [x]를 입력해 체크박스 채우기 가능 -->

- [x] 📜 PR 제목 형식을 잘 작성했나요?
- [x] 👀 리뷰어를 설정했나요?
- [x] 📊 프로젝트를 등록했나요?
- [x] 💭 이슈를 등록했나요?
- [x] 🏷️ 라벨을 등록했나요?
