### PR TITLE
비밀번호 찾기 & 재설정 기능 구현

### DIFF
--- a/src/hooks/queries/useUserInfo.tsx
+++ b/src/hooks/queries/useUserInfo.tsx
@@ -58,3 +58,41 @@ export const useUserResign = () => {
   const mutation = useMutation(userResign);
   return mutation;
 };
+
+export const useEmailValid = () => {
+  const emailValid = async (email: string) => {
+    console.log(email);
+    const response = await axiosInstance.post('/user/findemail/', {
+      email: email,
+    });
+
+    return response.data;
+  };
+  const mutation = useMutation(emailValid);
+  return mutation;
+};
+
+export const useFindPassword = () => {
+  const findPassword = async (email: string) => {
+    console.log(email);
+    const response = await axiosInstance.post('/user/find_pw/', {
+      email: email,
+    });
+
+    return response.data;
+  };
+  const mutation = useMutation(findPassword);
+  return mutation;
+};
+
+export const useSetNewPassword = () => {
+  const setNewPassword = async (password: string) => {
+    console.log(password);
+    const response = await privateInstance.put('/user/pwchange/', {
+      new_password: password,
+    });
+    return response.data;
+  };
+  const mutation = useMutation(setNewPassword);
+  return mutation;
+};

--- a/src/pages/FindPassword/FindPassword.tsx
+++ b/src/pages/FindPassword/FindPassword.tsx
@@ -1,0 +1,48 @@
+import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
+import BackBtnIcon from '../../img/left-arrow-Icon.svg';
+import FindPasswordForm from './FindPasswordForm';
+
+export default function FindPassword() {
+  const navigate = useNavigate();
+  return (
+    <FindPasswordWrap>
+      <BackBtn>
+        <button onClick={() => navigate(-1)}>
+          <img src={BackBtnIcon} alt='뒤로가기 버튼' />
+        </button>
+      </BackBtn>
+      <FindPasswordTitle>
+        본인확인을 위해
+        <br />
+        뮤딕아이디의 아이디를
+        <br />
+        입력해주세요
+      </FindPasswordTitle>
+      <FindPasswordForm />
+    </FindPasswordWrap>
+  );
+}
+
+const FindPasswordWrap = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+`;
+
+const BackBtn = styled.div`
+  position: absolute;
+  top: 22px;
+  left: 16px;
+`;
+
+const FindPasswordTitle = styled.h1`
+  font-size: var(--font-xl);
+  font-weight: var(--font-bold);
+  line-height: 33px;
+  position: relative;
+  top: 56px;
+
+  left: 16px;
+`;

--- a/src/pages/FindPassword/FindPassword.tsx
+++ b/src/pages/FindPassword/FindPassword.tsx
@@ -15,7 +15,7 @@ export default function FindPassword() {
       <FindPasswordTitle>
         본인확인을 위해
         <br />
-        뮤딕아이디의 아이디를
+        뮤딕아이디의 이메일을
         <br />
         입력해주세요
       </FindPasswordTitle>

--- a/src/pages/FindPassword/FindPasswordForm.tsx
+++ b/src/pages/FindPassword/FindPasswordForm.tsx
@@ -1,0 +1,130 @@
+import styled from 'styled-components';
+import { useForm, FormProvider, FieldValues } from 'react-hook-form';
+import { Button } from '../../components/common/Button/Button';
+import { SignupInput } from '../../components/common/Input/SignupInput';
+import { isLoginAtom, userInfoAtom } from '../../library/atom';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+import { useUserResign } from '../../hooks/queries/useUserInfo';
+import ResignModal from '../../components/common/Modal/ResignModal';
+import { useNavigate } from 'react-router-dom';
+import { toastAtom } from '../../library/atom';
+import { modalAtom } from '../../atoms/modalAtom';
+export default function FindPasswordForm() {
+  const emailRegex = /^\S+@\S+\.\S+$/;
+  const [isModalOpen, setModalOpen] = useRecoilState(modalAtom);
+  const setIsLogin = useSetRecoilState(isLoginAtom);
+  const setUserInfo = useSetRecoilState(userInfoAtom);
+  const setToast = useSetRecoilState(toastAtom);
+  const navigate = useNavigate();
+  const { mutate: userResign } = useUserResign();
+  const methods = useForm({
+    defaultValues: {
+      email: '',
+      password: '',
+    },
+
+    mode: 'onSubmit',
+  });
+
+  const { formState, setError, getValues } = methods;
+
+  const { isValid, errors } = formState;
+  const password = getValues('password');
+  const passwordError = errors['password'] as FieldValues['password'];
+
+  const handleResign = () => {
+    userResign(password, {
+      onSuccess: (data) => {
+        setIsLogin(false);
+        setUserInfo({
+          id: 0,
+          email: '',
+          name: '',
+          image: '',
+          genre: '',
+          about: '',
+          rep_playlist: null,
+          token: {
+            access: '',
+            refresh: '',
+          },
+        });
+        localStorage.removeItem('token');
+        localStorage.removeItem('refreshToken');
+        setToast({
+          content: '새 비밀번호 설정이 완료되었습니다. 다시 로그인 해주세요.',
+          type: 'success',
+        });
+        // console.log(data);
+      },
+
+      onError: (error) => {
+        console.error('회원탈퇴 실패', error);
+        setModalOpen(false);
+        setError('password', {
+          message: '현재 비밀번호가 일치하지 않습니다.',
+        });
+      },
+    });
+
+    setModalOpen(false);
+  };
+
+  const onSubmit = () => {
+    setModalOpen(true);
+  };
+
+  return (
+    <>
+      {isModalOpen && <ResignModal handleResign={handleResign} />}
+      <FormProvider {...methods}>
+        <FormWrap onSubmit={methods.handleSubmit(onSubmit)}>
+          <InputBox>
+            <SignupInput
+              validation={{
+                pattern: {
+                  value: emailRegex,
+                  message: '이메일 형식에 맞지 않는 메일주소 입니다.',
+                },
+                required: '이메일을 입력하세요',
+              }}
+              placeholder='이메일'
+              type='text'
+              name='email'
+            />
+          </InputBox>
+          <ButtonBox>
+            <Button
+              text='비밀번호 찾기'
+              type='submit'
+              disabled={!isValid || passwordError}
+            ></Button>
+          </ButtonBox>
+        </FormWrap>
+      </FormProvider>
+    </>
+  );
+}
+
+const FormWrap = styled.form`
+  flex: 1 0 0;
+  padding: 261px 16px 24px;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+`;
+
+const InputBox = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+`;
+
+const ButtonBox = styled.div`
+  width: 100%;
+
+  bottom: 24px;
+`;

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -137,14 +137,8 @@ export default function Login() {
           <NavUserInfoLink onClick={() => navigate('/register')}>
             회원가입
           </NavUserInfoLink>
-          <NavUserInfoLink
-            onClick={() =>
-              alert(
-                '아이디 · 비밀번호 찾기는 현재 개발 중입니다. 불편을 드려 죄송합니다. ',
-              )
-            }
-          >
-            아이디 · 비밀번호 찾기{' '}
+          <NavUserInfoLink onClick={() => navigate('/password/find')}>
+            비밀번호 찾기
           </NavUserInfoLink>
         </NavUserInfo>
       </LoginMain>

--- a/src/pages/ResetPassword/ResetPassword.tsx
+++ b/src/pages/ResetPassword/ResetPassword.tsx
@@ -1,10 +1,21 @@
 import styled from 'styled-components';
 import BackBtnIcon from '../../img/left-arrow-Icon.svg';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import ResetPasswordForm from './ResetPasswordForm';
+import { useEffect } from 'react';
 
 export default function ResetPassword() {
   const navigate = useNavigate();
+  const location = useLocation();
+  const searchParams = new URLSearchParams(location.search);
+
+  useEffect(() => {
+    const token = searchParams.get('token');
+    if (token) {
+      localStorage.setItem('token', token);
+    }
+  }, []);
+
   return (
     <UserLeavewWrap>
       <BackBtn>

--- a/src/pages/ResetPassword/ResetPassword.tsx
+++ b/src/pages/ResetPassword/ResetPassword.tsx
@@ -1,0 +1,46 @@
+import styled from 'styled-components';
+import BackBtnIcon from '../../img/left-arrow-Icon.svg';
+import { useNavigate } from 'react-router-dom';
+import ResetPasswordForm from './ResetPasswordForm';
+
+export default function ResetPassword() {
+  const navigate = useNavigate();
+  return (
+    <UserLeavewWrap>
+      <BackBtn>
+        <button onClick={() => navigate(-1)}>
+          <img src={BackBtnIcon} alt='뒤로가기 버튼' />
+        </button>
+      </BackBtn>
+      <UserLeaveTitle>
+        뮤딕 아이디의 <br /> 새 비밀번호를 설정해주세요
+      </UserLeaveTitle>
+      <ResetPasswordForm />
+    </UserLeavewWrap>
+  );
+}
+
+const UserLeavewWrap = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  /* position: relative;
+  padding: 0 16px; */
+`;
+
+const BackBtn = styled.div`
+  position: absolute;
+  top: 22px;
+  left: 16px;
+`;
+
+const UserLeaveTitle = styled.h1`
+  font-size: var(--font-xl);
+  font-weight: var(--font-bold);
+  line-height: 33px;
+  position: relative;
+  top: 56px;
+
+  left: 16px;
+`;

--- a/src/pages/ResetPassword/ResetPasswordForm.tsx
+++ b/src/pages/ResetPassword/ResetPasswordForm.tsx
@@ -1,0 +1,166 @@
+import React from 'react';
+import styled from 'styled-components';
+import { useForm, FormProvider } from 'react-hook-form';
+import { Button } from '../../components/common/Button/Button';
+import { SignupInput } from '../../components/common/Input/SignupInput';
+import usePasswordToggle from '../../hooks/ussPasswordToggle';
+import { isLoginAtom, toastAtom, userInfoAtom } from '../../library/atom';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useChangePassword } from '../../hooks/queries/useUserInfo';
+import { useNavigate } from 'react-router-dom';
+interface IFormData {
+  email?: string;
+  password: string;
+  newPassword: string;
+  confirmPassword: string;
+}
+export default function ResetPasswordForm() {
+  const navigate = useNavigate();
+  const userEmail = useRecoilValue(userInfoAtom)?.email;
+  const { mutate: changePassword } = useChangePassword();
+  const setIsLogin = useSetRecoilState(isLoginAtom);
+  const setUserInfo = useSetRecoilState(userInfoAtom);
+  const setToast = useSetRecoilState(toastAtom);
+  const pawwrodRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).{8,16}$/;
+  const methods = useForm({
+    defaultValues: {
+      email: userEmail,
+      password: '',
+      newPassword: '',
+      confirmPassword: '',
+    },
+
+    mode: 'onBlur',
+  });
+
+  const { formState, setError, watch, getValues } = methods;
+  const { isValid } = formState;
+
+  const handlePasswordSubmit = (data: IFormData) => {
+    changePassword(data, {
+      onSuccess: (data) => {
+        setToast({
+          content: '비밀번호 변경이 완료되었습니다.',
+          type: 'success',
+        });
+        setIsLogin(false);
+        setUserInfo({
+          id: 0,
+          email: '',
+          name: '',
+          image: '',
+          genre: '',
+          about: '',
+          rep_playlist: null,
+          token: {
+            access: '',
+            refresh: '',
+          },
+        });
+        localStorage.removeItem('token');
+        localStorage.removeItem('refreshToken');
+        navigate('/login');
+      },
+      onError: (error) => {
+        console.error('비밀번호 변경 실패', error);
+        setError('password', { message: '현재 비밀번호가 일치하지 않습니다.' });
+      },
+    });
+  };
+  const { toggleShowPassword, showPassword } = usePasswordToggle();
+  return (
+    <FormProvider {...methods}>
+      <FormWrap onSubmit={methods.handleSubmit(handlePasswordSubmit)}>
+        <InputBox>
+          <InputTitle>이메일 </InputTitle>
+          <SignupInput placeholder='이메일' type='text' name='email' />
+
+          <InputTitle>새 비밀번호</InputTitle>
+          <SignupInput
+            validation={{
+              pattern: {
+                value: pawwrodRegex,
+                message:
+                  '비밀번호는 8~16자 영문 대 소문자, 숫자를 조합해서 사용하세요.',
+              },
+
+              required:
+                '비밀번호는 8~16자 영문 대 소문자, 숫자를 조합해서 사용하세요.',
+            }}
+            placeholder='새 비밀번호'
+            type='password'
+            name='newPassword'
+            showPassword={showPassword.newPassword}
+            toggleShowPassword={() => toggleShowPassword('newPassword')}
+          />
+          <InputTitle>새 비밀번호 확인</InputTitle>
+          <SignupInput
+            validation={{
+              pattern: {
+                value: pawwrodRegex,
+                message:
+                  '비밀번호는 8~16자 영문 대 소문자, 숫자를 조합해서 사용하세요.',
+              },
+              validate: {
+                comfirmPw: (fieldValue: string) => {
+                  return (
+                    fieldValue == watch('newPassword') ||
+                    '새 비밀번호와 새 비밀번호 확인이 일치하지 않습니다. '
+                  );
+                },
+              },
+
+              required:
+                '비밀번호는 8~16자 영문 대 소문자, 숫자를 조합해서 사용하세요.',
+            }}
+            placeholder='새 비밀번호 확인'
+            type='password'
+            name='confirmPassword'
+            showPassword={showPassword.confirmPassword}
+            toggleShowPassword={() => toggleShowPassword('confirmPassword')}
+          />
+        </InputBox>
+        <ButtonBox>
+          <Button
+            text='변경'
+            type='submit'
+            onClick={() => handlePasswordSubmit(getValues())}
+            disabled={!isValid}
+          ></Button>
+        </ButtonBox>
+      </FormWrap>
+    </FormProvider>
+  );
+}
+
+const FormWrap = styled.form`
+  flex: 1 0 0;
+  padding: 241px 16px 24px;
+  width: 100%;
+  display: flex;
+  overflow-y: scroll;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+  flex-direction: column;
+  justify-content: space-between;
+`;
+
+const InputTitle = styled.p`
+  font-size: var(--font-md);
+`;
+
+const InputBox = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+
+  gap: 4px;
+  /* gap: 4px; */
+`;
+
+const ButtonBox = styled.div`
+  width: 100%;
+
+  bottom: 24px;
+`;

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -30,6 +30,8 @@ import RecentSearch from '../components/Search/RecentSearch';
 import Comment from '../pages/PlaylistDetail/Comment';
 import Reply from '../pages/PlaylistDetail/Reply';
 import MorePlaylist from '../pages/Home/MorePlaylist';
+import FindPassword from '../pages/FindPassword/FindPassword';
+import ResetPassword from '../pages/ResetPassword/ResetPassword';
 
 export function Router() {
   return (
@@ -63,6 +65,8 @@ export function Router() {
             <Route path='profile/:id/follow' element={<Follow />} />
             <Route path='profile/edit' element={<EditProfile />} />
             <Route path='password' element={<ChangePassword />} />
+            <Route path='password/find' element={<FindPassword />} />
+            <Route path='password/reset' element={<ResetPassword />} />
             <Route path='resign' element={<Resign />} />
           </Route>
           <Route path='/playlist/detail'>

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -42,6 +42,8 @@ export function Router() {
         <Route path='/register' element={<Signup />} />
         <Route path='/register/detail' element={<SignupDetail />} />
         <Route path='/setprofile' element={<SetProfile />} />
+        <Route path='/password/find' element={<FindPassword />} />
+        <Route path='/password/reset' element={<ResetPassword />} />
         <Route element={<PrivateRoute />}>
           <Route path='/event' element={<EventPage />} />
           <Route path='/main' element={<Outlet />}>
@@ -65,8 +67,6 @@ export function Router() {
             <Route path='profile/:id/follow' element={<Follow />} />
             <Route path='profile/edit' element={<EditProfile />} />
             <Route path='password' element={<ChangePassword />} />
-            <Route path='password/find' element={<FindPassword />} />
-            <Route path='password/reset' element={<ResetPassword />} />
             <Route path='resign' element={<Resign />} />
           </Route>
           <Route path='/playlist/detail'>


### PR DESCRIPTION
## PR 타입

<!-- 하나 이상 선택, [x]를 입력해 체크박스 채우기 가능 -->

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 변경 브랜치

ex) refactor/seojun -> develop

## 변경 사항

<!-- 해당 기능 / 변경사항을 작업한 내용을 요약해 작성 -->
- 비밀번호 찾기 시  이메일 유효성 검사 후 해당 메일로 비밀번호 재설정 메일 전송
- 비밀번호 재설정 메일 링크를 통해 새 비밀번호 설정 페이지로 이동 후 유저 토큰값 추출하여 새 비밀번호 설정 요청  

비밀번호 재설정 이메일 링크 접속시 
https://localhost:3000/password/reset?로 기본경로로 접근시 localhost에서 잘못된 응답을 전송했습니다.라는 오류가 뜰 텐데 
https=> http로 변경 후 확인하면 해당 페이지가 잘 보입니다
위 문제는 main push 후 로컬 주소를 뮤딕 페이지 주소로 변경하면 해결될 문제이기에 로컬 확인용입니다.

## PR 체크리스트

 <!-- 마지막으로 PR을 만들기 전 확인할 목록, [x]를 입력해 체크박스 채우기 가능 -->

- [x] 📜 PR 제목 형식을 잘 작성했나요?
- [x] 👀 리뷰어를 설정했나요?
- [x] 📊 프로젝트를 등록했나요?
- [x] 💭 이슈를 등록했나요?
- [x] 🏷️ 라벨을 등록했나요?
